### PR TITLE
Bootstrap branch 3.0.0-wip is no longer exposed so changed the docs to c...

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Currently the `assemble.css` stylesheet is used in the examples, but the project
 To do so, from the root of the project `git clone` Bootstrap:
 
 ```bash
-git clone -b 3.0.0-wip https://github.com/twbs/bootstrap.git "vendor/bootstrap"
+git clone -b master https://github.com/twbs/bootstrap.git "vendor/bootstrap"
 ```
 (the "less" task is currently configured to use the `vendor` directory)
 


### PR DESCRIPTION
...lone Bootstrap's master branch.
